### PR TITLE
Corrected grammar in dataset_object.rst

### DIFF
--- a/docs/source/tabular/usage_guides/dataset_object.rst
+++ b/docs/source/tabular/usage_guides/dataset_object.rst
@@ -147,8 +147,8 @@ Inferring Categorical Features
 
 .. warning::
     It is highly recommended to explicitly state the categorical features or define their column type to be ``category``.
-    Otherwise, the inherent limitations of the automatic, and may cause inconsistencies (misdetection, different detection between
-    train and test, etc.), and required tuning and adaptions.
+    Otherwise, the inherent limitations of the automatic may cause inconsistencies (misdetection, different detection between
+    train and test, etc.) and require tuning and adaptions.
 
 If the parameter ``cat_features`` was not passed explicitly, the following inference logic 
 will run on the columns to determine which are classified as categorical:


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #2660

#### Description of fixes

There might be grammar and logic issues in the paragraph below (suggested changes are marked in bold):

**_SUGGESTED TEXT_**

It is highly recommended to explicitly state the categorical features or define their column type to be ``category``.
Otherwise, the inherent limitations of the **automatic may cause** inconsistencies (misdetection, different detection between train and test, etc.**) and require** tuning and adaptions.
